### PR TITLE
Fix: Add hub_routing_preference to virtual hub configuration

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -24,8 +24,8 @@ jobs:
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 #v4.1.2
 
       - name: check docs
-        uses: Azure/terraform-azurerm-avm-template/.github/actions/docs-check@main
-
+        uses: lonegunmanb/terraform-azurerm-avm-template/.github/actions/docs-check@debug
+        
   terraform:
     if: github.event.repository.name != 'terraform-azurerm-avm-template'
     name: terraform

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -24,8 +24,8 @@ jobs:
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 #v4.1.2
 
       - name: check docs
-        uses: lonegunmanb/terraform-azurerm-avm-template/.github/actions/docs-check@debug
-        
+        uses: Azure/terraform-azurerm-avm-template/.github/actions/docs-check@main
+
   terraform:
     if: github.event.repository.name != 'terraform-azurerm-avm-template'
     name: terraform

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SHELL := /bin/bash
 
 # Commenting out the below line to exclude GoFumpt from the avmmakefile
-# $(shell curl -H 'Cache-Control: no-cache, no-store' -sSL "https://raw.githubusercontent.com/Azure/tfmod-scaffold/main/avmmakefile" -o avmmakefile)
+$(shell curl -H 'Cache-Control: no-cache, no-store' -sSL "https://raw.githubusercontent.com/Azure/tfmod-scaffold/main/avmmakefile" -o avmmakefile)
 -include avmmakefile

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 SHELL := /bin/bash
 
-$(shell curl -H 'Cache-Control: no-cache, no-store' -sSL "https://raw.githubusercontent.com/Azure/tfmod-scaffold/main/avmmakefile" -o avmmakefile)
+# Commenting out the below line to exclude GoFumpt from the avmmakefile
+# $(shell curl -H 'Cache-Control: no-cache, no-store' -sSL "https://raw.githubusercontent.com/Azure/tfmod-scaffold/main/avmmakefile" -o avmmakefile)
 -include avmmakefile

--- a/README.md
+++ b/README.md
@@ -391,11 +391,11 @@ Default: `{}`
 
 ### <a name="input_tags"></a> [tags](#input\_tags)
 
-Description: Overall tags
+Description: (Optional) Tags of the resource.
 
 Type: `map(string)`
 
-Default: `{}`
+Default: `null`
 
 ### <a name="input_telemetry_resource_group_name"></a> [telemetry\_resource\_group\_name](#input\_telemetry\_resource\_group\_name)
 
@@ -421,11 +421,12 @@ Type:
 
 ```hcl
 map(object({
-    name           = string
-    location       = string
-    resource_group = optional(string, null)
-    address_prefix = string
-    tags           = optional(map(string))
+    name                   = string
+    location               = string
+    resource_group         = optional(string, null)
+    address_prefix         = string
+    tags                   = optional(map(string))
+    hub_routing_preference = optional(string)
   }))
 ```
 

--- a/examples/s2svpn/customer_vpn.tf
+++ b/examples/s2svpn/customer_vpn.tf
@@ -49,7 +49,7 @@ resource "azurerm_virtual_network_gateway" "gw" {
   location            = azurerm_resource_group.rg.location
   name                = local.on_prem_vnet_gateway_name
   resource_group_name = azurerm_resource_group.rg.name
-  sku                 = "VpnGw1"
+  sku                 = "AzVpnGw1"
   type                = "Vpn"
   active_active       = false
   enable_bgp          = true

--- a/examples/s2svpn/customer_vpn.tf
+++ b/examples/s2svpn/customer_vpn.tf
@@ -49,7 +49,7 @@ resource "azurerm_virtual_network_gateway" "gw" {
   location            = azurerm_resource_group.rg.location
   name                = local.on_prem_vnet_gateway_name
   resource_group_name = azurerm_resource_group.rg.name
-  sku                 = "AzVpnGw1"
+  sku                 = "VpnGw1AZ"
   type                = "Vpn"
   active_active       = false
   enable_bgp          = true

--- a/locals.tf
+++ b/locals.tf
@@ -49,12 +49,12 @@ locals {
   }
   virtual_hubs = {
     for key, vhub in var.virtual_hubs : key => {
-      name           = vhub.name
-      location       = vhub.location
-      resource_group = try(vhub.resource_group, "")
-      address_prefix = vhub.address_prefix
+      name                   = vhub.name
+      location               = vhub.location
+      resource_group         = try(vhub.resource_group, "")
+      address_prefix         = vhub.address_prefix
       hub_routing_preference = try(vhub.hub_routing_preference, "")
-      tags           = try(vhub.tags, {})
+      tags                   = try(vhub.tags, {})
     }
   }
   virtual_network_connections = {

--- a/locals.tf
+++ b/locals.tf
@@ -53,6 +53,7 @@ locals {
       location       = vhub.location
       resource_group = try(vhub.resource_group, "")
       address_prefix = vhub.address_prefix
+      hub_routing_preference = try(vhub.hub_routing_preference, "")
       tags           = try(vhub.tags, {})
     }
   }

--- a/main.tf
+++ b/main.tf
@@ -31,11 +31,11 @@ resource "azurerm_virtual_wan" "virtual_wan" {
 resource "azurerm_virtual_hub" "virtual_hub" {
   for_each = local.virtual_hubs != null && length(local.virtual_hubs) > 0 ? local.virtual_hubs : {}
 
-  location            = each.value.location
-  name                = each.value.name
-  resource_group_name = local.resource_group_name
-  address_prefix      = each.value.address_prefix
-  tags                = try(each.value.tags, {})
-  virtual_wan_id      = azurerm_virtual_wan.virtual_wan.id
+  location               = each.value.location
+  name                   = each.value.name
+  resource_group_name    = local.resource_group_name
+  address_prefix         = each.value.address_prefix
+  tags                   = try(each.value.tags, {})
+  virtual_wan_id         = azurerm_virtual_wan.virtual_wan.id
   hub_routing_preference = each.value.hub_routing_preference
 }

--- a/main.tf
+++ b/main.tf
@@ -37,4 +37,5 @@ resource "azurerm_virtual_hub" "virtual_hub" {
   address_prefix      = each.value.address_prefix
   tags                = try(each.value.tags, {})
   virtual_wan_id      = azurerm_virtual_wan.virtual_wan.id
+  hub_routing_preference = each.value.hub_routing_preference
 }

--- a/main.tf
+++ b/main.tf
@@ -35,7 +35,7 @@ resource "azurerm_virtual_hub" "virtual_hub" {
   name                   = each.value.name
   resource_group_name    = local.resource_group_name
   address_prefix         = each.value.address_prefix
+  hub_routing_preference = each.value.hub_routing_preference
   tags                   = try(each.value.tags, {})
   virtual_wan_id         = azurerm_virtual_wan.virtual_wan.id
-  hub_routing_preference = each.value.hub_routing_preference
 }

--- a/variables.tf
+++ b/variables.tf
@@ -213,6 +213,7 @@ variable "virtual_hubs" {
     resource_group = optional(string, null)
     address_prefix = string
     tags           = optional(map(string))
+    hub_routing_preference = optional(string)
   }))
   default     = {}
   description = "Virtual Hub parameters"

--- a/variables.tf
+++ b/variables.tf
@@ -208,11 +208,11 @@ variable "type" {
 
 variable "virtual_hubs" {
   type = map(object({
-    name           = string
-    location       = string
-    resource_group = optional(string, null)
-    address_prefix = string
-    tags           = optional(map(string))
+    name                   = string
+    location               = string
+    resource_group         = optional(string, null)
+    address_prefix         = string
+    tags                   = optional(map(string))
     hub_routing_preference = optional(string)
   }))
   default     = {}

--- a/variables.tf
+++ b/variables.tf
@@ -195,10 +195,10 @@ variable "routing_intents" {
 
 # General tags for all resources
 variable "tags" {
-    type     = map(string)
-    default  = null
-    description = "(Optional) Tags of the resource."
-  }
+  type        = map(string)
+  default     = null
+  description = "(Optional) Tags of the resource."
+}
 
 variable "type" {
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -195,10 +195,10 @@ variable "routing_intents" {
 
 # General tags for all resources
 variable "tags" {
-  type        = map(string)
-  default     = {}
-  description = "Overall tags"
-}
+    type     = map(string)
+    default  = null
+    description = "(Optional) Tags of the resource."
+  }
 
 variable "type" {
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -193,7 +193,7 @@ variable "routing_intents" {
   nullable    = false
 }
 
-# General tags for all resources
+# General tags for all resources in pattern
 variable "tags" {
   type        = map(string)
   default     = null


### PR DESCRIPTION
## Description
Fix: Add `hub_routing_preference` to virtual hub configuration, to allow configuration of routing outside of the default `ExpressRoute`


<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #456
-->
Fixes #55 


## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `locals.version.tf.json`:
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `locals.version.tf.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `locals.version.tf.json`.
  - [ ] Update to documentation

# Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
