### PR TITLE
bug: replace removed outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -787,7 +787,15 @@ Description: Azure Firewall IP addresses.
 
 Description: A map of Azure Firewall private IP addresses with the map keys of the `firewalls` variable.
 
+### <a name="output_firewall_private_ip_addresses_by_hub_key"></a> [firewall\_private\_ip\_addresses\_by\_hub\_key](#output\_firewall\_private\_ip\_addresses\_by\_hub\_key)
+
+Description: A map of Azure Firewall private IP addresses with the map keys of the `firewalls` variable.
+
 ### <a name="output_firewall_public_ip_addresses"></a> [firewall\_public\_ip\_addresses](#output\_firewall\_public\_ip\_addresses)
+
+Description: A map of Azure Firewall public IP addresses with the map keys of the `firewalls` variable.
+
+### <a name="output_firewall_public_ip_addresses_by_hub_key"></a> [firewall\_public\_ip\_addresses\_by\_hub\_key](#output\_firewall\_public\_ip\_addresses\_by\_hub\_key)
 
 Description: A map of Azure Firewall public IP addresses with the map keys of the `firewalls` variable.
 
@@ -795,7 +803,15 @@ Description: A map of Azure Firewall public IP addresses with the map keys of th
 
 Description: A map of Azure Firewall resource IDs with the map keys of the `firewalls` variable.
 
+### <a name="output_firewall_resource_ids_by_hub_key"></a> [firewall\_resource\_ids\_by\_hub\_key](#output\_firewall\_resource\_ids\_by\_hub\_key)
+
+Description: A map of Azure Firewall resource IDs with the map keys of the `firewalls` variable.
+
 ### <a name="output_firewall_resource_names"></a> [firewall\_resource\_names](#output\_firewall\_resource\_names)
+
+Description: A map of Azure Firewall resource names with the map keys of the `firewalls` variable.
+
+### <a name="output_firewall_resource_names_by_hub_key"></a> [firewall\_resource\_names\_by\_hub\_key](#output\_firewall\_resource\_names\_by\_hub\_key)
 
 Description: A map of Azure Firewall resource names with the map keys of the `firewalls` variable.
 

--- a/README.md
+++ b/README.md
@@ -783,6 +783,26 @@ The following outputs are exported:
 
 Description: Azure Firewall IP addresses.
 
+### <a name="output_firewall_private_ip_addresses"></a> [firewall\_private\_ip\_addresses](#output\_firewall\_private\_ip\_addresses)
+
+Description: A map of Azure Firewall private IP addresses with the map keys of the `firewalls` variable.
+
+### <a name="output_firewall_public_ip_addresses"></a> [firewall\_public\_ip\_addresses](#output\_firewall\_public\_ip\_addresses)
+
+Description: A map of Azure Firewall public IP addresses with the map keys of the `firewalls` variable.
+
+### <a name="output_firewall_resource_ids"></a> [firewall\_resource\_ids](#output\_firewall\_resource\_ids)
+
+Description: A map of Azure Firewall resource IDs with the map keys of the `firewalls` variable.
+
+### <a name="output_firewall_resource_names"></a> [firewall\_resource\_names](#output\_firewall\_resource\_names)
+
+Description: A map of Azure Firewall resource names with the map keys of the `firewalls` variable.
+
+### <a name="output_name"></a> [name](#output\_name)
+
+Description: Virtual WAN Name
+
 ### <a name="output_p2s_vpn_gw_id"></a> [p2s\_vpn\_gw\_id](#output\_p2s\_vpn\_gw\_id)
 
 Description: P2S VPN Gateway ID
@@ -814,6 +834,14 @@ Description: S2S VPN Gateway Objects
 ### <a name="output_s2s_vpn_gw_id"></a> [s2s\_vpn\_gw\_id](#output\_s2s\_vpn\_gw\_id)
 
 Description: S2S VPN Gateway ID
+
+### <a name="output_virtual_hub_resource_ids"></a> [virtual\_hub\_resource\_ids](#output\_virtual\_hub\_resource\_ids)
+
+Description: A map of Azure Virtual Hub resource IDs with the map keys of the `virtual_hubs` variable.
+
+### <a name="output_virtual_hub_resource_names"></a> [virtual\_hub\_resource\_names](#output\_virtual\_hub\_resource\_names)
+
+Description: A map of Azure Virtual Hub resource names with the map keys of the `virtual_hubs` variable.
 
 ### <a name="output_virtual_wan_id"></a> [virtual\_wan\_id](#output\_virtual\_wan\_id)
 

--- a/examples/firewall-linked-firewall-policy/README.md
+++ b/examples/firewall-linked-firewall-policy/README.md
@@ -82,7 +82,7 @@ output "test" {
     name                                     = module.vwan_with_vhub.name
     firewall_resource_ids                    = module.vwan_with_vhub.firewall_resource_ids
     firewall_resource_names                  = module.vwan_with_vhub.firewall_resource_names
-    firewall_private_ip_addresses            = module.vwan_with_vhub.firewall_ip_addresses
+    firewall_private_ip_addresses            = module.vwan_with_vhub.firewall_private_ip_addresses
     firewall_public_ip_addresses             = module.vwan_with_vhub.firewall_public_ip_addresses
     firewall_resource_ids_by_hub_key         = module.vwan_with_vhub.firewall_resource_ids_by_hub_key
     firewall_resource_names_by_hub_key       = module.vwan_with_vhub.firewall_resource_names_by_hub_key

--- a/examples/firewall-linked-firewall-policy/README.md
+++ b/examples/firewall-linked-firewall-policy/README.md
@@ -78,14 +78,18 @@ output "firewall_private_ip_address" {
 
 output "test" {
   value = {
-    resource_id                   = module.vwan_with_vhub.resource_id
-    name                          = module.vwan_with_vhub.name
-    firewall_resource_ids         = module.vwan_with_vhub.firewall_resource_ids
-    firewall_resource_names       = module.vwan_with_vhub.firewall_resource_names
-    firewall_private_ip_addresses = module.vwan_with_vhub.firewall_ip_addresses
-    firewall_public_ip_addresses  = module.vwan_with_vhub.firewall_public_ip_addresses
-    virtual_hub_resource_ids      = module.vwan_with_vhub.virtual_hub_resource_ids
-    virtual_hub_resource_names    = module.vwan_with_vhub.virtual_hub_resource_names
+    resource_id                              = module.vwan_with_vhub.resource_id
+    name                                     = module.vwan_with_vhub.name
+    firewall_resource_ids                    = module.vwan_with_vhub.firewall_resource_ids
+    firewall_resource_names                  = module.vwan_with_vhub.firewall_resource_names
+    firewall_private_ip_addresses            = module.vwan_with_vhub.firewall_ip_addresses
+    firewall_public_ip_addresses             = module.vwan_with_vhub.firewall_public_ip_addresses
+    firewall_resource_ids_by_hub_key         = module.vwan_with_vhub.firewall_resource_ids_by_hub_key
+    firewall_resource_names_by_hub_key       = module.vwan_with_vhub.firewall_resource_names_by_hub_key
+    firewall_private_ip_addresses_by_hub_key = module.vwan_with_vhub.firewall_private_ip_addresses_by_hub_key
+    firewall_public_ip_addresses_by_hub_key  = module.vwan_with_vhub.firewall_public_ip_addresses_by_hub_key
+    virtual_hub_resource_ids                 = module.vwan_with_vhub.virtual_hub_resource_ids
+    virtual_hub_resource_names               = module.vwan_with_vhub.virtual_hub_resource_names
   }
 }
 ```

--- a/examples/firewall-linked-firewall-policy/README.md
+++ b/examples/firewall-linked-firewall-policy/README.md
@@ -75,6 +75,19 @@ output "firewall_private_ip_address" {
   description = "Private IP Address of the Azure Firewall by Hub"
   value       = module.vwan_with_vhub.firewall_ip_addresses
 }
+
+output "test" {
+  value = {
+    resource_id                   = module.vwan_with_vhub.resource_id
+    name                          = module.vwan_with_vhub.name
+    firewall_resource_ids         = module.vwan_with_vhub.firewall_resource_ids
+    firewall_resource_names       = module.vwan_with_vhub.firewall_resource_names
+    firewall_private_ip_addresses = module.vwan_with_vhub.firewall_ip_addresses
+    firewall_public_ip_addresses  = module.vwan_with_vhub.firewall_public_ip_addresses
+    virtual_hub_resource_ids      = module.vwan_with_vhub.virtual_hub_resource_ids
+    virtual_hub_resource_names    = module.vwan_with_vhub.virtual_hub_resource_names
+  }
+}
 ```
 
 <!-- markdownlint-disable MD033 -->
@@ -111,6 +124,10 @@ The following outputs are exported:
 ### <a name="output_firewall_private_ip_address"></a> [firewall\_private\_ip\_address](#output\_firewall\_private\_ip\_address)
 
 Description: Private IP Address of the Azure Firewall by Hub
+
+### <a name="output_test"></a> [test](#output\_test)
+
+Description: n/a
 
 ## Modules
 

--- a/examples/firewall-linked-firewall-policy/main.tf
+++ b/examples/firewall-linked-firewall-policy/main.tf
@@ -72,13 +72,17 @@ output "firewall_private_ip_address" {
 
 output "test" {
   value = {
-    resource_id                   = module.vwan_with_vhub.resource_id
-    name                          = module.vwan_with_vhub.name
-    firewall_resource_ids         = module.vwan_with_vhub.firewall_resource_ids
-    firewall_resource_names       = module.vwan_with_vhub.firewall_resource_names
-    firewall_private_ip_addresses = module.vwan_with_vhub.firewall_ip_addresses
-    firewall_public_ip_addresses  = module.vwan_with_vhub.firewall_public_ip_addresses
-    virtual_hub_resource_ids      = module.vwan_with_vhub.virtual_hub_resource_ids
-    virtual_hub_resource_names    = module.vwan_with_vhub.virtual_hub_resource_names
+    resource_id                              = module.vwan_with_vhub.resource_id
+    name                                     = module.vwan_with_vhub.name
+    firewall_resource_ids                    = module.vwan_with_vhub.firewall_resource_ids
+    firewall_resource_names                  = module.vwan_with_vhub.firewall_resource_names
+    firewall_private_ip_addresses            = module.vwan_with_vhub.firewall_ip_addresses
+    firewall_public_ip_addresses             = module.vwan_with_vhub.firewall_public_ip_addresses
+    firewall_resource_ids_by_hub_key         = module.vwan_with_vhub.firewall_resource_ids_by_hub_key
+    firewall_resource_names_by_hub_key       = module.vwan_with_vhub.firewall_resource_names_by_hub_key
+    firewall_private_ip_addresses_by_hub_key = module.vwan_with_vhub.firewall_private_ip_addresses_by_hub_key
+    firewall_public_ip_addresses_by_hub_key  = module.vwan_with_vhub.firewall_public_ip_addresses_by_hub_key
+    virtual_hub_resource_ids                 = module.vwan_with_vhub.virtual_hub_resource_ids
+    virtual_hub_resource_names               = module.vwan_with_vhub.virtual_hub_resource_names
   }
 }

--- a/examples/firewall-linked-firewall-policy/main.tf
+++ b/examples/firewall-linked-firewall-policy/main.tf
@@ -76,7 +76,7 @@ output "test" {
     name                                     = module.vwan_with_vhub.name
     firewall_resource_ids                    = module.vwan_with_vhub.firewall_resource_ids
     firewall_resource_names                  = module.vwan_with_vhub.firewall_resource_names
-    firewall_private_ip_addresses            = module.vwan_with_vhub.firewall_ip_addresses
+    firewall_private_ip_addresses            = module.vwan_with_vhub.firewall_private_ip_addresses
     firewall_public_ip_addresses             = module.vwan_with_vhub.firewall_public_ip_addresses
     firewall_resource_ids_by_hub_key         = module.vwan_with_vhub.firewall_resource_ids_by_hub_key
     firewall_resource_names_by_hub_key       = module.vwan_with_vhub.firewall_resource_names_by_hub_key

--- a/examples/firewall-linked-firewall-policy/main.tf
+++ b/examples/firewall-linked-firewall-policy/main.tf
@@ -69,3 +69,16 @@ output "firewall_private_ip_address" {
   description = "Private IP Address of the Azure Firewall by Hub"
   value       = module.vwan_with_vhub.firewall_ip_addresses
 }
+
+output "test" {
+  value = {
+    resource_id                   = module.vwan_with_vhub.resource_id
+    name                          = module.vwan_with_vhub.name
+    firewall_resource_ids         = module.vwan_with_vhub.firewall_resource_ids
+    firewall_resource_names       = module.vwan_with_vhub.firewall_resource_names
+    firewall_private_ip_addresses = module.vwan_with_vhub.firewall_ip_addresses
+    firewall_public_ip_addresses  = module.vwan_with_vhub.firewall_public_ip_addresses
+    virtual_hub_resource_ids      = module.vwan_with_vhub.virtual_hub_resource_ids
+    virtual_hub_resource_names    = module.vwan_with_vhub.virtual_hub_resource_names
+  }
+}

--- a/examples/vhub/README.md
+++ b/examples/vhub/README.md
@@ -44,14 +44,18 @@ module "vwan_with_vhub" {
 
 output "test" {
   value = {
-    resource_id                   = module.vwan_with_vhub.resource_id
-    name                          = module.vwan_with_vhub.name
-    firewall_resource_ids         = module.vwan_with_vhub.firewall_resource_ids
-    firewall_resource_names       = module.vwan_with_vhub.firewall_resource_names
-    firewall_private_ip_addresses = module.vwan_with_vhub.firewall_ip_addresses
-    firewall_public_ip_addresses  = module.vwan_with_vhub.firewall_public_ip_addresses
-    virtual_hub_resource_ids      = module.vwan_with_vhub.virtual_hub_resource_ids
-    virtual_hub_resource_names    = module.vwan_with_vhub.virtual_hub_resource_names
+    resource_id                              = module.vwan_with_vhub.resource_id
+    name                                     = module.vwan_with_vhub.name
+    firewall_resource_ids                    = module.vwan_with_vhub.firewall_resource_ids
+    firewall_resource_names                  = module.vwan_with_vhub.firewall_resource_names
+    firewall_private_ip_addresses            = module.vwan_with_vhub.firewall_ip_addresses
+    firewall_public_ip_addresses             = module.vwan_with_vhub.firewall_public_ip_addresses
+    firewall_resource_ids_by_hub_key         = module.vwan_with_vhub.firewall_resource_ids_by_hub_key
+    firewall_resource_names_by_hub_key       = module.vwan_with_vhub.firewall_resource_names_by_hub_key
+    firewall_private_ip_addresses_by_hub_key = module.vwan_with_vhub.firewall_private_ip_addresses_by_hub_key
+    firewall_public_ip_addresses_by_hub_key  = module.vwan_with_vhub.firewall_public_ip_addresses_by_hub_key
+    virtual_hub_resource_ids                 = module.vwan_with_vhub.virtual_hub_resource_ids
+    virtual_hub_resource_names               = module.vwan_with_vhub.virtual_hub_resource_names
   }
 }
 ```

--- a/examples/vhub/README.md
+++ b/examples/vhub/README.md
@@ -48,7 +48,7 @@ output "test" {
     name                                     = module.vwan_with_vhub.name
     firewall_resource_ids                    = module.vwan_with_vhub.firewall_resource_ids
     firewall_resource_names                  = module.vwan_with_vhub.firewall_resource_names
-    firewall_private_ip_addresses            = module.vwan_with_vhub.firewall_ip_addresses
+    firewall_private_ip_addresses            = module.vwan_with_vhub.firewall_private_ip_addresses
     firewall_public_ip_addresses             = module.vwan_with_vhub.firewall_public_ip_addresses
     firewall_resource_ids_by_hub_key         = module.vwan_with_vhub.firewall_resource_ids_by_hub_key
     firewall_resource_names_by_hub_key       = module.vwan_with_vhub.firewall_resource_names_by_hub_key

--- a/examples/vhub/README.md
+++ b/examples/vhub/README.md
@@ -41,6 +41,19 @@ module "vwan_with_vhub" {
     }
   }
 }
+
+output "test" {
+  value = {
+    resource_id                   = module.vwan_with_vhub.resource_id
+    name                          = module.vwan_with_vhub.name
+    firewall_resource_ids         = module.vwan_with_vhub.firewall_resource_ids
+    firewall_resource_names       = module.vwan_with_vhub.firewall_resource_names
+    firewall_private_ip_addresses = module.vwan_with_vhub.firewall_ip_addresses
+    firewall_public_ip_addresses  = module.vwan_with_vhub.firewall_public_ip_addresses
+    virtual_hub_resource_ids      = module.vwan_with_vhub.virtual_hub_resource_ids
+    virtual_hub_resource_names    = module.vwan_with_vhub.virtual_hub_resource_names
+  }
+}
 ```
 
 <!-- markdownlint-disable MD033 -->
@@ -71,7 +84,11 @@ No optional inputs.
 
 ## Outputs
 
-No outputs.
+The following outputs are exported:
+
+### <a name="output_test"></a> [test](#output\_test)
+
+Description: n/a
 
 ## Modules
 

--- a/examples/vhub/main.tf
+++ b/examples/vhub/main.tf
@@ -38,13 +38,17 @@ module "vwan_with_vhub" {
 
 output "test" {
   value = {
-    resource_id                   = module.vwan_with_vhub.resource_id
-    name                          = module.vwan_with_vhub.name
-    firewall_resource_ids         = module.vwan_with_vhub.firewall_resource_ids
-    firewall_resource_names       = module.vwan_with_vhub.firewall_resource_names
-    firewall_private_ip_addresses = module.vwan_with_vhub.firewall_ip_addresses
-    firewall_public_ip_addresses  = module.vwan_with_vhub.firewall_public_ip_addresses
-    virtual_hub_resource_ids      = module.vwan_with_vhub.virtual_hub_resource_ids
-    virtual_hub_resource_names    = module.vwan_with_vhub.virtual_hub_resource_names
+    resource_id                              = module.vwan_with_vhub.resource_id
+    name                                     = module.vwan_with_vhub.name
+    firewall_resource_ids                    = module.vwan_with_vhub.firewall_resource_ids
+    firewall_resource_names                  = module.vwan_with_vhub.firewall_resource_names
+    firewall_private_ip_addresses            = module.vwan_with_vhub.firewall_ip_addresses
+    firewall_public_ip_addresses             = module.vwan_with_vhub.firewall_public_ip_addresses
+    firewall_resource_ids_by_hub_key         = module.vwan_with_vhub.firewall_resource_ids_by_hub_key
+    firewall_resource_names_by_hub_key       = module.vwan_with_vhub.firewall_resource_names_by_hub_key
+    firewall_private_ip_addresses_by_hub_key = module.vwan_with_vhub.firewall_private_ip_addresses_by_hub_key
+    firewall_public_ip_addresses_by_hub_key  = module.vwan_with_vhub.firewall_public_ip_addresses_by_hub_key
+    virtual_hub_resource_ids                 = module.vwan_with_vhub.virtual_hub_resource_ids
+    virtual_hub_resource_names               = module.vwan_with_vhub.virtual_hub_resource_names
   }
 }

--- a/examples/vhub/main.tf
+++ b/examples/vhub/main.tf
@@ -42,7 +42,7 @@ output "test" {
     name                                     = module.vwan_with_vhub.name
     firewall_resource_ids                    = module.vwan_with_vhub.firewall_resource_ids
     firewall_resource_names                  = module.vwan_with_vhub.firewall_resource_names
-    firewall_private_ip_addresses            = module.vwan_with_vhub.firewall_ip_addresses
+    firewall_private_ip_addresses            = module.vwan_with_vhub.firewall_private_ip_addresses
     firewall_public_ip_addresses             = module.vwan_with_vhub.firewall_public_ip_addresses
     firewall_resource_ids_by_hub_key         = module.vwan_with_vhub.firewall_resource_ids_by_hub_key
     firewall_resource_names_by_hub_key       = module.vwan_with_vhub.firewall_resource_names_by_hub_key

--- a/examples/vhub/main.tf
+++ b/examples/vhub/main.tf
@@ -35,3 +35,16 @@ module "vwan_with_vhub" {
     }
   }
 }
+
+output "test" {
+  value = {
+    resource_id                   = module.vwan_with_vhub.resource_id
+    name                          = module.vwan_with_vhub.name
+    firewall_resource_ids         = module.vwan_with_vhub.firewall_resource_ids
+    firewall_resource_names       = module.vwan_with_vhub.firewall_resource_names
+    firewall_private_ip_addresses = module.vwan_with_vhub.firewall_ip_addresses
+    firewall_public_ip_addresses  = module.vwan_with_vhub.firewall_public_ip_addresses
+    virtual_hub_resource_ids      = module.vwan_with_vhub.virtual_hub_resource_ids
+    virtual_hub_resource_names    = module.vwan_with_vhub.virtual_hub_resource_names
+  }
+}

--- a/modules/firewall/README.md
+++ b/modules/firewall/README.md
@@ -97,6 +97,14 @@ The following outputs are exported:
 
 Description: Azure Firewall resource name
 
+### <a name="output_private_ip_addresses"></a> [private\_ip\_addresses](#output\_private\_ip\_addresses)
+
+Description: Azure Firewall IP addresses
+
+### <a name="output_public_ip_addresses"></a> [public\_ip\_addresses](#output\_public\_ip\_addresses)
+
+Description: Azure Firewall IP addresses
+
 ### <a name="output_resource"></a> [resource](#output\_resource)
 
 Description: Azure Firewall resource
@@ -104,6 +112,14 @@ Description: Azure Firewall resource
 ### <a name="output_resource_id"></a> [resource\_id](#output\_resource\_id)
 
 Description: Azure Firewall resource ID
+
+### <a name="output_resource_ids"></a> [resource\_ids](#output\_resource\_ids)
+
+Description: Azure Firewall resource IDs
+
+### <a name="output_resource_names"></a> [resource\_names](#output\_resource\_names)
+
+Description: Azure Firewall resource names
 
 ### <a name="output_resource_object"></a> [resource\_object](#output\_resource\_object)
 

--- a/modules/firewall/output.tf
+++ b/modules/firewall/output.tf
@@ -23,3 +23,23 @@ output "resource_object" {
     }
   } : {}
 }
+
+output "resource_ids" {
+  description = "Azure Firewall resource IDs"
+  value       = var.firewalls != null ? { for key, value in azurerm_firewall.fw : key => value.id } : null
+}
+
+output "resource_names" {
+  description = "Azure Firewall resource names"
+  value       = var.firewalls != null ? { for key, value in azurerm_firewall.fw : key => value.name } : null
+}
+
+output "private_ip_addresses" {
+  description = "Azure Firewall IP addresses"
+  value       = var.firewalls != null ? { for key, value in azurerm_firewall.fw : key => value.virtual_hub[0].private_ip_address } : null
+}
+
+output "public_ip_addresses" {
+  description = "Azure Firewall IP addresses"
+  value       = var.firewalls != null ? { for key, value in azurerm_firewall.fw : key => value.virtual_hub[0].public_ip_addresses } : null
+}

--- a/modules/virtualhub/README.md
+++ b/modules/virtualhub/README.md
@@ -102,6 +102,14 @@ Description: Resource Group Name
 
 Description: Virtual Hub ID
 
+### <a name="output_resource_ids"></a> [resource\_ids](#output\_resource\_ids)
+
+Description: Virtual Hub IDs
+
+### <a name="output_resource_names"></a> [resource\_names](#output\_resource\_names)
+
+Description: Virtual Hub Names
+
 ### <a name="output_resource_object"></a> [resource\_object](#output\_resource\_object)
 
 Description: Virtual Hub Object

--- a/modules/virtualhub/output.tf
+++ b/modules/virtualhub/output.tf
@@ -31,3 +31,13 @@ output "resource_object" {
     }
   }
 }
+
+output "resource_ids" {
+  description = "Virtual Hub IDs"
+  value       = { for key, hub in azurerm_virtual_hub.virtual_hub : key => hub.id }
+}
+
+output "resource_names" {
+  description = "Virtual Hub Names"
+  value       = { for key, hub in azurerm_virtual_hub.virtual_hub : key => hub.name }
+}

--- a/outputs.standard.tf
+++ b/outputs.standard.tf
@@ -1,0 +1,39 @@
+output "resource_id" {
+  description = "Virtual WAN ID"
+  value       = azurerm_virtual_wan.virtual_wan.id
+}
+
+output "name" {
+  description = "Virtual WAN Name"
+  value       = azurerm_virtual_wan.virtual_wan.name
+}
+
+output "firewall_resource_ids" {
+  description = "A map of Azure Firewall resource IDs with the map keys of the `firewalls` variable."
+  value       = module.firewalls.resource_ids
+}
+
+output "firewall_resource_names" {
+  description = "A map of Azure Firewall resource names with the map keys of the `firewalls` variable."
+  value       = module.firewalls.resource_names
+}
+
+output "firewall_private_ip_addresses" {
+  description = "A map of Azure Firewall private IP addresses with the map keys of the `firewalls` variable."
+  value       = module.firewalls.private_ip_addresses
+}
+
+output "firewall_public_ip_addresses" {
+  description = "A map of Azure Firewall public IP addresses with the map keys of the `firewalls` variable."
+  value       = module.firewalls.public_ip_addresses
+}
+
+output "virtual_hub_resource_ids" {
+  description = "A map of Azure Virtual Hub resource IDs with the map keys of the `virtual_hubs` variable."
+  value       = module.virtual_hubs.resource_ids
+}
+
+output "virtual_hub_resource_names" {
+  description = "A map of Azure Virtual Hub resource names with the map keys of the `virtual_hubs` variable."
+  value       = module.virtual_hubs.resource_names
+}

--- a/outputs.standard.tf
+++ b/outputs.standard.tf
@@ -28,6 +28,26 @@ output "firewall_public_ip_addresses" {
   value       = module.firewalls.public_ip_addresses
 }
 
+output "firewall_resource_ids_by_hub_key" {
+  description = "A map of Azure Firewall resource IDs with the map keys of the `firewalls` variable."
+  value       = { for key, value in var.firewalls : value.virtual_hub_key => module.firewalls.resource_ids[key] }
+}
+
+output "firewall_resource_names_by_hub_key" {
+  description = "A map of Azure Firewall resource names with the map keys of the `firewalls` variable."
+  value       = { for key, value in var.firewalls : value.virtual_hub_key => module.firewalls.resource_names[key] }
+}
+
+output "firewall_private_ip_addresses_by_hub_key" {
+  description = "A map of Azure Firewall private IP addresses with the map keys of the `firewalls` variable."
+  value       = { for key, value in var.firewalls : value.virtual_hub_key => module.firewalls.private_ip_addresses[key] }
+}
+
+output "firewall_public_ip_addresses_by_hub_key" {
+  description = "A map of Azure Firewall public IP addresses with the map keys of the `firewalls` variable."
+  value       = { for key, value in var.firewalls : value.virtual_hub_key => module.firewalls.public_ip_addresses[key] }
+}
+
 output "virtual_hub_resource_ids" {
   description = "A map of Azure Virtual Hub resource IDs with the map keys of the `virtual_hubs` variable."
   value       = module.virtual_hubs.resource_ids

--- a/outputs.tf
+++ b/outputs.tf
@@ -31,11 +31,6 @@ output "resource_group_name" {
   value       = local.resource_group_name
 }
 
-output "resource_id" {
-  description = "Virtual WAN ID"
-  value       = azurerm_virtual_wan.virtual_wan != null ? [azurerm_virtual_wan.virtual_wan.id] : var.virtual_hubs != null ? [for hub in module.virtual_hubs : hub.id] : []
-}
-
 output "s2s_vpn_gw" {
   description = "S2S VPN Gateway Objects"
   value       = var.vpn_gateways != null ? [for gw in module.vpn_gateway.resource_object : gw] : null


### PR DESCRIPTION
## Description

A bunch of outputs required for ALZ were removed in theis PR: https://github.com/Azure/terraform-azurerm-avm-ptn-virtualwan/pull/133/files#diff-de6c47c2496bd028a84d55ab12d8a4f90174ebfb6544b8b5c7b07a7ee4f27ec7

This PR is to re-implement them and standardise the outputs where possible.

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [x] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
