### PR TITLE
Fix: corrected submodule arguments and added output for private IP of firewall

### DIFF
--- a/avm.tflint_module.hcl
+++ b/avm.tflint_module.hcl
@@ -6,7 +6,7 @@ plugin "terraform" {
 
 plugin "avm" {
   enabled     = true
-  version     = "0.11.5"
+  version     = "0.14.1"
   source      = "github.com/Azure/tflint-ruleset-avm"
   signing_key = <<-KEY
 -----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -188,6 +188,10 @@ rule "tags" {
   enabled = true
 }
 
-rule "provider_modtm_version" {
+rule "provider_modtm_version_constraint" {
   enabled = false
+}
+
+rule "valid_template_interpolation" {
+  enabled = true
 }

--- a/examples/firewall-linked-firewall-policy/README.md
+++ b/examples/firewall-linked-firewall-policy/README.md
@@ -56,6 +56,7 @@ module "vwan_with_vhub" {
       name               = local.firewall_name
       virtual_hub_key    = local.virtual_hub_key
       firewall_policy_id = azurerm_firewall_policy.this.id
+      zones              = [1, 2]
     }
   }
   routing_intents = {

--- a/examples/firewall-linked-firewall-policy/main.tf
+++ b/examples/firewall-linked-firewall-policy/main.tf
@@ -50,6 +50,7 @@ module "vwan_with_vhub" {
       name               = local.firewall_name
       virtual_hub_key    = local.virtual_hub_key
       firewall_policy_id = azurerm_firewall_policy.this.id
+      zones              = [1, 2]
     }
   }
   routing_intents = {

--- a/examples/s2svpn/README.md
+++ b/examples/s2svpn/README.md
@@ -55,6 +55,7 @@ module "vwan_with_vhub" {
     (local.vpn_gateways_key) = {
       name            = local.vpn_gateways_name
       virtual_hub_key = local.virtual_hub_key
+      scale_unit      = 1
     }
   }
   vpn_sites = {

--- a/examples/s2svpn/main.tf
+++ b/examples/s2svpn/main.tf
@@ -49,6 +49,7 @@ module "vwan_with_vhub" {
     (local.vpn_gateways_key) = {
       name            = local.vpn_gateways_name
       virtual_hub_key = local.virtual_hub_key
+      scale_unit      = 1
     }
   }
   vpn_sites = {

--- a/firewall.tf
+++ b/firewall.tf
@@ -11,6 +11,7 @@ module "firewalls" {
       tags                 = value.tags
       virtual_hub_id       = module.virtual_hubs.resource_object[value.virtual_hub_key].id
       vhub_public_ip_count = value.vhub_public_ip_count
+      zones                = value.zones
     }
   }
 }

--- a/modules/firewall/README.md
+++ b/modules/firewall/README.md
@@ -14,6 +14,7 @@ resource "azurerm_firewall" "fw" {
   sku_tier            = each.value.sku_tier
   firewall_policy_id  = each.value.firewall_policy_id
   tags                = try(each.value.tags, {})
+  zones               = each.value.zones
 
   virtual_hub {
     virtual_hub_id  = each.value.virtual_hub_id

--- a/modules/firewall/main.tf
+++ b/modules/firewall/main.tf
@@ -8,6 +8,7 @@ resource "azurerm_firewall" "fw" {
   sku_tier            = each.value.sku_tier
   firewall_policy_id  = each.value.firewall_policy_id
   tags                = try(each.value.tags, {})
+  zones               = each.value.zones
 
   virtual_hub {
     virtual_hub_id  = each.value.virtual_hub_id

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,8 +1,9 @@
 output "firewall_ip_addresses" {
   description = "Azure Firewall IP addresses."
   value = var.firewalls != null ? { for key, value in module.firewalls.resource_object : key => {
-    firewall_key      = key
-    public_ip_address = module.firewalls.resource_object[key].virtual_hub[0].public_ip_addresses
+    firewall_key       = key
+    private_ip_address = module.firewalls.resource_object[key].virtual_hub[0].private_ip_addresses
+    public_ip_address  = module.firewalls.resource_object[key].virtual_hub[0].public_ip_addresses
   } } : null
 }
 

--- a/s2s-vpn-gateway.tf
+++ b/s2s-vpn-gateway.tf
@@ -8,7 +8,7 @@ module "vpn_gateway" {
       location                              = module.virtual_hubs.resource_object[value.virtual_hub_key].location
       virtual_hub_id                        = module.virtual_hubs.resource_object[value.virtual_hub_key].id
       bgp_route_translation_for_nat_enabled = value.bgp_route_translation_for_nat_enabled
-      scale_units                           = value.scale_unit
+      scale_unit                            = value.scale_unit
       routing_preference                    = value.routing_preference
       bgp_settings                          = value.bgp_settings
     }


### PR DESCRIPTION
## Description

- Added firewalls private IPs to the outputs. Fixes #106
- Pass through `zones` attribute to submodule and amend submodule to set attribute. Previously you could configure this attribute but it wasn't set at the resource level. Closes #145 
- Corrected the s2s vpn gateway scale unit argument being passed to submodule incorrectly. Closes #143 

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [X] Azure Verified Module updates:
  - [X] Bugfix containing backwards compatible bug fixes
    - [X] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [X] I'm sure there are no other open Pull Requests for the same update/change
- [X] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
