### PR TITLE
fix: correct type of traffic_selector_policy attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -703,8 +703,8 @@ map(object({
       outbound_route_map_id = optional(string)
     }))
     traffic_selector_policy = optional(object({
-      local_address_ranges  = string
-      remote_address_ranges = string
+      local_address_ranges  = list(string)
+      remote_address_ranges = list(string)
     }))
   }))
 ```

--- a/modules/site-to-site-gateway-conn/variables.tf
+++ b/modules/site-to-site-gateway-conn/variables.tf
@@ -45,8 +45,8 @@ variable "vpn_site_connection" {
       outbound_route_map_id = optional(string)
     }))
     traffic_selector_policy = optional(object({
-      local_address_ranges  = string
-      remote_address_ranges = string
+      local_address_ranges  = list(string)
+      remote_address_ranges = list(string)
     }))
   }))
   description = "S2S VPN Site Connections parameter"

--- a/variables.tf
+++ b/variables.tf
@@ -510,8 +510,8 @@ variable "vpn_site_connections" {
       outbound_route_map_id = optional(string)
     }))
     traffic_selector_policy = optional(object({
-      local_address_ranges  = string
-      remote_address_ranges = string
+      local_address_ranges  = list(string)
+      remote_address_ranges = list(string)
     }))
   }))
   default     = {}


### PR DESCRIPTION
## Description

Changes the attributes "local_address_ranges" and "remote_address_ranges" of "traffic_selector_policy" in the "vpn_site_connection" resource to the correct type of "list(string)"

Closes #166

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [x] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
