### PR TITLE
feat: add optional attribute sku on virtual_hubs

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,6 +480,7 @@ Description:   Map of objects for Virtual Hubs to deploy into the Virtual WAN.
   - `location`: Location for the Virtual Hub resource.
   - `resource_group`: Optional resource group name to deploy the Virtual Hub into. If not specified, the Virtual Hub will be deployed into the resource group specified in the variable `resource_group_name`, e.g. the same as the Virtual WAN itself.
   - `address_prefix`: Address prefix for the Virtual Hub. Recommend using a `/23` CIDR block.
+  - `sku`: Optional SKU for the Virtual Hub. Possible values are: `Standard` or `Basic`.
   - `tags`: Optional tags to apply to the Virtual Hub resource.
   - `hub_routing_preference`: Optional hub routing preference for the Virtual Hub. Possible values are: `ExpressRoute`, `ASPath`, `VpnGateway`. Defaults to `ExpressRoute`. See https://learn.microsoft.com/azure/virtual-wan/hub-settings#routing-preference for more information.
   - `virtual_router_auto_scale_min_capacity`: Optional minimum capacity for the Virtual Router auto scale. Defaults to `2`. See https://learn.microsoft.com/azure/virtual-wan/hub-settings#capacity for more information.
@@ -494,6 +495,7 @@ map(object({
     location                               = string
     resource_group                         = optional(string, null)
     address_prefix                         = string
+    sku                                    = optional(string, null)
     tags                                   = optional(map(string))
     hub_routing_preference                 = optional(string, "ExpressRoute")
     virtual_router_auto_scale_min_capacity = optional(number, 2)

--- a/modules/virtualhub/main.tf
+++ b/modules/virtualhub/main.tf
@@ -7,6 +7,7 @@ resource "azurerm_virtual_hub" "virtual_hub" {
   resource_group_name                    = each.value.resource_group
   address_prefix                         = each.value.address_prefix
   hub_routing_preference                 = each.value.hub_routing_preference
+  sku                                    = each.value.sku
   tags                                   = each.value.tags
   virtual_router_auto_scale_min_capacity = each.value.virtual_router_auto_scale_min_capacity
   virtual_wan_id                         = each.value.virtual_wan_id

--- a/modules/virtualhub/variables.tf
+++ b/modules/virtualhub/variables.tf
@@ -4,6 +4,7 @@ variable "virtual_hubs" {
     location                               = string
     resource_group                         = optional(string, null)
     address_prefix                         = string
+    sku                                    = optional(string, null)
     tags                                   = optional(map(string))
     virtual_wan_id                         = string
     hub_routing_preference                 = optional(string, "ExpressRoute")
@@ -19,6 +20,7 @@ variable "virtual_hubs" {
   - `location`: Location for the Virtual Hub resource.
   - `resource_group`: Optional resource group name to deploy the Virtual Hub into. If not specified, the Virtual Hub will be deployed into the resource group specified in the variable `resource_group_name`, e.g. the same as the Virtual WAN itself.
   - `address_prefix`: Address prefix for the Virtual Hub. Recommend using a `/23` CIDR block.
+  - `sku`: Optional SKU for the Virtual Hub. Possible values are: `Standard` or `Basic`.
   - `tags`: Optional tags to apply to the Virtual Hub resource.
   - `hub_routing_preference`: Optional hub routing preference for the Virtual Hub. Possible values are: `ExpressRoute`, `ASPath`, `VpnGateway`. Defaults to `ExpressRoute`. See https://learn.microsoft.com/azure/virtual-wan/hub-settings#routing-preference for more information.
   - `virtual_router_auto_scale_min_capacity`: Optional minimum capacity for the Virtual Router auto scale. Defaults to `2`. See https://learn.microsoft.com/azure/virtual-wan/hub-settings#capacity for more information.

--- a/variables.tf
+++ b/variables.tf
@@ -339,6 +339,7 @@ variable "virtual_hubs" {
     location                               = string
     resource_group                         = optional(string, null)
     address_prefix                         = string
+    sku                                    = optional(string, null)
     tags                                   = optional(map(string))
     hub_routing_preference                 = optional(string, "ExpressRoute")
     virtual_router_auto_scale_min_capacity = optional(number, 2)
@@ -353,6 +354,7 @@ variable "virtual_hubs" {
   - `location`: Location for the Virtual Hub resource.
   - `resource_group`: Optional resource group name to deploy the Virtual Hub into. If not specified, the Virtual Hub will be deployed into the resource group specified in the variable `resource_group_name`, e.g. the same as the Virtual WAN itself.
   - `address_prefix`: Address prefix for the Virtual Hub. Recommend using a `/23` CIDR block.
+  - `sku`: Optional SKU for the Virtual Hub. Possible values are: `Standard` or `Basic`.
   - `tags`: Optional tags to apply to the Virtual Hub resource.
   - `hub_routing_preference`: Optional hub routing preference for the Virtual Hub. Possible values are: `ExpressRoute`, `ASPath`, `VpnGateway`. Defaults to `ExpressRoute`. See https://learn.microsoft.com/azure/virtual-wan/hub-settings#routing-preference for more information.
   - `virtual_router_auto_scale_min_capacity`: Optional minimum capacity for the Virtual Router auto scale. Defaults to `2`. See https://learn.microsoft.com/azure/virtual-wan/hub-settings#capacity for more information.


### PR DESCRIPTION
## Description
Adds the possibility to set SKU on azurerm_virtual_hub resource in the module, to allow for importing existing virtual hubs.

Fixes #165

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [x] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [x] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
