### PR TITLE
fix: allow null virtual hub sku for backwards compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,6 +481,7 @@ Description:   Map of objects for Virtual Hubs to deploy into the Virtual WAN.
   - `resource_group`: Optional resource group name to deploy the Virtual Hub into. If not specified, the Virtual Hub will be deployed into the resource group specified in the variable `resource_group_name`, e.g. the same as the Virtual WAN itself.
   - `address_prefix`: Address prefix for the Virtual Hub. Recommend using a `/23` CIDR block.
   - `tags`: Optional tags to apply to the Virtual Hub resource.
+  - `sku`: Optional SKU for the Virtual Hub. Possible values are: `Standard`, `Basic`. Defaults to `null` for backwards compatibility. See https://learn.microsoft.com/en-gb/azure/virtual-wan/hub-settings#type for more information.
   - `hub_routing_preference`: Optional hub routing preference for the Virtual Hub. Possible values are: `ExpressRoute`, `ASPath`, `VpnGateway`. Defaults to `ExpressRoute`. See https://learn.microsoft.com/azure/virtual-wan/hub-settings#routing-preference for more information.
   - `virtual_router_auto_scale_min_capacity`: Optional minimum capacity for the Virtual Router auto scale. Defaults to `2`. See https://learn.microsoft.com/azure/virtual-wan/hub-settings#capacity for more information.
 
@@ -495,7 +496,7 @@ map(object({
     resource_group                         = optional(string, null)
     address_prefix                         = string
     tags                                   = optional(map(string))
-    sku                                    = optional(string, "Standard")
+    sku                                    = optional(string, null)
     hub_routing_preference                 = optional(string, "ExpressRoute")
     virtual_router_auto_scale_min_capacity = optional(number, 2)
   }))

--- a/locals.tf
+++ b/locals.tf
@@ -59,7 +59,7 @@ locals {
       resource_group                         = try(vhub.resource_group, "")
       address_prefix                         = vhub.address_prefix
       hub_routing_preference                 = try(vhub.hub_routing_preference, "")
-      sku                                    = try(vhub.sku, "Standard")
+      sku                                    = try(vhub.sku, null)
       tags                                   = try(vhub.tags, null) == null ? var.tags : vhub.tags
       virtual_router_auto_scale_min_capacity = vhub.virtual_router_auto_scale_min_capacity
     }

--- a/variables.tf
+++ b/variables.tf
@@ -340,7 +340,7 @@ variable "virtual_hubs" {
     resource_group                         = optional(string, null)
     address_prefix                         = string
     tags                                   = optional(map(string))
-    sku                                    = optional(string, "Standard")
+    sku                                    = optional(string, null)
     hub_routing_preference                 = optional(string, "ExpressRoute")
     virtual_router_auto_scale_min_capacity = optional(number, 2)
   }))
@@ -355,6 +355,7 @@ variable "virtual_hubs" {
   - `resource_group`: Optional resource group name to deploy the Virtual Hub into. If not specified, the Virtual Hub will be deployed into the resource group specified in the variable `resource_group_name`, e.g. the same as the Virtual WAN itself.
   - `address_prefix`: Address prefix for the Virtual Hub. Recommend using a `/23` CIDR block.
   - `tags`: Optional tags to apply to the Virtual Hub resource.
+  - `sku`: Optional SKU for the Virtual Hub. Possible values are: `Standard`, `Basic`. Defaults to `null` for backwards compatibility. See https://learn.microsoft.com/en-gb/azure/virtual-wan/hub-settings#type for more information.
   - `hub_routing_preference`: Optional hub routing preference for the Virtual Hub. Possible values are: `ExpressRoute`, `ASPath`, `VpnGateway`. Defaults to `ExpressRoute`. See https://learn.microsoft.com/azure/virtual-wan/hub-settings#routing-preference for more information.
   - `virtual_router_auto_scale_min_capacity`: Optional minimum capacity for the Virtual Router auto scale. Defaults to `2`. See https://learn.microsoft.com/azure/virtual-wan/hub-settings#capacity for more information.
 


### PR DESCRIPTION
## Description

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #456
-->

The provider defaults to Standard sku if null is supplied, but if Standard is explicitly set it plans to destroy and recreate the resource. This is a provider bug, but allow null to be set here to ensure backwards compatibility.

Fixes: https://github.com/Azure/terraform-azurerm-avm-ptn-virtualwan/issues/174

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
