### PR TITLE
fix: allow null virtual hub sku for backwards compatibility (v2)

### DIFF
--- a/main.telemetry.tf
+++ b/main.telemetry.tf
@@ -15,11 +15,11 @@ resource "random_uuid" "telemetry" {
 resource "modtm_telemetry" "telemetry" {
   count = var.enable_telemetry ? 1 : 0
 
-  tags = {
+  tags = merge({
     subscription_id = one(data.azurerm_client_config.telemetry).subscription_id
     tenant_id       = one(data.azurerm_client_config.telemetry).tenant_id
     module_source   = one(data.modtm_module_source.telemetry).module_source
     module_version  = one(data.modtm_module_source.telemetry).module_version
     random_id       = one(random_uuid.telemetry).result
-  }
+  }, { location = var.location })
 }

--- a/modules/site-to-site-gateway-conn/README.md
+++ b/modules/site-to-site-gateway-conn/README.md
@@ -162,8 +162,8 @@ map(object({
       outbound_route_map_id = optional(string)
     }))
     traffic_selector_policy = optional(object({
-      local_address_ranges  = string
-      remote_address_ranges = string
+      local_address_ranges  = list(string)
+      remote_address_ranges = list(string)
     }))
   }))
 ```

--- a/modules/virtualhub/README.md
+++ b/modules/virtualhub/README.md
@@ -78,7 +78,7 @@ map(object({
     virtual_wan_id                         = string
     hub_routing_preference                 = optional(string, "ExpressRoute")
     virtual_router_auto_scale_min_capacity = optional(number, 2)
-    sku                                    = optional(string, "Standard")
+    sku                                    = optional(string, null)
   }))
 ```
 

--- a/modules/virtualhub/variables.tf
+++ b/modules/virtualhub/variables.tf
@@ -8,7 +8,7 @@ variable "virtual_hubs" {
     virtual_wan_id                         = string
     hub_routing_preference                 = optional(string, "ExpressRoute")
     virtual_router_auto_scale_min_capacity = optional(number, 2)
-    sku                                    = optional(string, "Standard")
+    sku                                    = optional(string, null)
   }))
   default     = {}
   description = <<DESCRIPTION


### PR DESCRIPTION
## Description

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #456
-->

Fixes https://github.com/Azure/terraform-azurerm-avm-ptn-virtualwan/issues/178

cc @jaredfholgate 

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [x] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
~- [ ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks~

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
